### PR TITLE
Suggest row (page) size on initialization

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -429,15 +429,23 @@
       var scrollBody = Polymer.dom(aha.root).querySelector('.scroll-body.aha-table');
       var rowHeight = 42;
 
+      var closestPageSize;
+
       var optimizePageSize = Math.floor((Number(scrollBody.offsetHeight) - Number(th.offsetHeight)) / rowHeight);
       if (optimizePageSize <= 10) {
-        pagi._updatePageSize(10);
-      } else if (10 < optimizePageSize <= 20) {
-        pagi._updatePageSize(20);
-      } else if (20 < optimizePageSize <= 50) {
-        pagi._updatePageSize(50);
+        closestPageSize = 10;
+      } else if ((10 < optimizePageSize) &&(optimizePageSize <= 20)) {
+        closestPageSize = 20;
+      } else if ((20 < optimizePageSize) &&(optimizePageSize <= 50)) {
+        closestPageSize = 50;
       } else {
-        pagi._updatePageSize(100);
+        closestPageSize = 100;
+      }
+
+      if (!this.dataRemote) {
+        pagi._updatePageSize(closestPageSize);
+      }else {
+        this.fire('data-table-init', closestPageSize);
       }
     },
 

--- a/aha-table.html
+++ b/aha-table.html
@@ -416,14 +416,19 @@
       var boundHandler = this._columnChanged.bind(this);
       this._observer = Polymer.dom(this.$.columndefs).observeNodes(boundHandler);
     },
+
     attached: function () {
       this._isAttached = true;
 
-      window.addEventListener("load", this._optimizePageForLoad(this));
+      window.addEventListener("load", this._initializeTable(this));
+    },
+
+    detached: function () {
+      window.removeEventListener("load", this._initializeTable);
     },
 
     //This function will enable pageSize change at the initial load
-    _optimizePageForLoad: function (aha) {
+    _initializeTable: function (aha) {
       var pagi = Polymer.dom(aha.root).querySelector('#pagination');
       var th = Polymer.dom(aha.root).querySelector('.tr.aha-table');
       var scrollBody = Polymer.dom(aha.root).querySelector('.scroll-body.aha-table');
@@ -444,10 +449,8 @@
 
       if (!this.dataRemote) {
         pagi._updatePageSize(closestPageSize);
-      }else {
-        var obj = {};
-        obj.pageSize = closestPageSize;
-        this.fire('data-table-init', obj);
+      } else {
+        this.fire('data-table-init', { pageSize: closestPageSize });
       }
     },
 

--- a/aha-table.html
+++ b/aha-table.html
@@ -445,7 +445,9 @@
       if (!this.dataRemote) {
         pagi._updatePageSize(closestPageSize);
       }else {
-        this.fire('data-table-init', closestPageSize);
+        var obj = {};
+        obj.pageSize = closestPageSize;
+        this.fire('data-table-init', obj);
       }
     },
 

--- a/test/px-data-table-fixture.html
+++ b/test/px-data-table-fixture.html
@@ -175,7 +175,7 @@
       </px-data-table>
 
       <p>Greedy height with Scroll</p>
-      <div id="flexContainer1" style=" height:300px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
+      <div style=" height:300px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
         <px-data-table
           enable-column-resize="true"
           greedy-height-with-scroll="true"
@@ -188,11 +188,11 @@
       </div>
 
       <p>Smart Row Selection, client</p>
-      <div id="flexContainer2" style=" height:800px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
+      <div style=" height:800px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
         <px-data-table
           enable-column-resize="true"
           greedy-height-with-scroll="true"
-          id="clientSmartRowSelectionWithLargeHeight"
+          id="greedyHeightWithScrollLarge"
           show-column-chooser="true"
           table-rows="true"
           >
@@ -200,11 +200,11 @@
       </div>
 
       <p>Smart Row Selection, server</p>
-      <div id="flexContainer3" style=" height:900px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
+      <div style=" height:900px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
         <px-data-table
           enable-column-resize="true"
           greedy-height-with-scroll="true"
-          id="serverSmartRowSelectionWithLargeHeight"
+          id="greedyHeightWithScrollDataRemote"
           show-column-chooser="true"
           data-remote="true"
           table-rows="true"

--- a/test/px-data-table-fixture.html
+++ b/test/px-data-table-fixture.html
@@ -161,14 +161,39 @@
       </px-data-table>
 
 
-      <p>Greedy-height with Scroll</p>
-      <div id="styledContainer" style=" height:300px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
+      <p>Greedy height with Scroll</p>
+      <div id="styledContainer1" style=" height:300px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
         <px-data-table
           enable-column-resize="true"
           greedy-height-with-scroll="true"
           id="greedyHeightWithScroll"
           page-size="10"
           show-column-chooser="true"
+          table-rows="true"
+          >
+        </px-data-table>
+      </div>
+
+      <p>Smart Row Selection, client</p>
+      <div id="styledContainer2" style=" height:800px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
+        <px-data-table
+          enable-column-resize="true"
+          greedy-height-with-scroll="true"
+          id="clientSmartRowSelectionWithLargeHeight"
+          show-column-chooser="true"
+          table-rows="true"
+          >
+        </px-data-table>
+      </div>
+
+      <p>Smart Row Selection, server</p>
+      <div id="styledContainer3" style=" height:900px; border: 1px solid cyan; flex:1; display:flex; flex-direction:column; ">
+        <px-data-table
+          enable-column-resize="true"
+          greedy-height-with-scroll="true"
+          id="serverSmartRowSelectionWithLargeHeight"
+          show-column-chooser="true"
+          data-remote="true"
           table-rows="true"
           >
         </px-data-table>

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -1,4 +1,4 @@
-var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, filtertest, resetDataFixture, additionalDataFixture, updateSelectFixture, remoteDataFixture1, remoteDataFixture2, remoteDataFixture3;
+var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, filtertest, resetDataFixture, additionalDataFixture, updateSelectFixture, remoteDataFixture1, remoteDataFixture2, remoteDataFixture3, greedyHeightWithScrollFixture, clientSmartRowSelectionWithLargeHeightFixture, serverSmartRowSelectionWithLargeHeightFixture;
 var getStyle = function (el, style){
   return window.getComputedStyle( el, null ).getPropertyValue( style );
 };
@@ -787,8 +787,14 @@ document.addEventListener("WebComponentsReady", function() {
   remoteDataFixture3 = document.getElementById('remoteData3');
   remoteDataFixture3.tableData = minidata;
 
-  greedyHeightWithScroll = document.getElementById('greedyHeightWithScroll');
-  greedyHeightWithScroll.tableData = minidata;
+  greedyHeightWithScrollFixture = document.getElementById('greedyHeightWithScroll');
+  greedyHeightWithScrollFixture.tableData = minidata;
+
+  clientSmartRowSelectionWithLargeHeightFixture = document.getElementById('clientSmartRowSelectionWithLargeHeight');
+  clientSmartRowSelectionWithLargeHeightFixture.tableData = minidata;
+
+  serverSmartRowSelectionWithLargeHeightFixture = document.getElementById('serverSmartRowSelectionWithLargeHeight');
+  serverSmartRowSelectionWithLargeHeightFixture.tableData = minidata;
 
   runTests();
 });
@@ -1589,6 +1595,32 @@ function runTests() {
         assert.equal(paginationTextString, '1-20 of 100', 'Shows correct pagination counts.');
       });
 
+    });
+
+    suite('smart row selection for client or server side pagination', function () {
+      test('_optimizePageForLoad for client with small view size', function(done) {
+        var pxTable = document.getElementById('greedyHeightWithScroll');
+        var container = Polymer.dom(this.root).querySelector('#styledContainer1');
+        var pageSizeSelect = pxTable.querySelector('#pageSizeSelect');
+        assert.equal(pageSizeSelect.value, 10, 'small view size select page size 10');
+        done();
+      });
+
+      test('_optimizePageForLoad for client with large view size', function(done) {
+        var pxTable = document.getElementById('clientSmartRowSelectionWithLargeHeight');
+        var container = Polymer.dom(this.root).querySelector('#styledContainer2');
+        var pageSizeSelect = pxTable.querySelector('#pageSizeSelect');
+        assert.equal(pageSizeSelect.value, 20, 'large view size select closest page size');
+        done();
+      });
+
+       test('_optimizePageForLoad for remote data is true', function(done) {
+        var pxTable = document.getElementById('serverSmartRowSelectionWithLargeHeight');
+        var container = Polymer.dom(this.root).querySelector('#styledContainer3');
+        var pageSizeSelect = pxTable.querySelector('#pageSizeSelect');
+        assert.equal(pageSizeSelect.value, 10, 'server side pagination send out the closest page size as requested page size');
+        done();
+      });
     });
 
   });

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -799,10 +799,10 @@ document.addEventListener("WebComponentsReady", function() {
   greedyHeightWithScrollFixture = document.getElementById('greedyHeightWithScroll');
   greedyHeightWithScrollFixture.tableData = minidata;
 
-  clientSmartRowSelectionWithLargeHeightFixture = document.getElementById('clientSmartRowSelectionWithLargeHeight');
+  clientSmartRowSelectionWithLargeHeightFixture = document.getElementById('greedyHeightWithScrollLarge');
   clientSmartRowSelectionWithLargeHeightFixture.tableData = minidata;
 
-  serverSmartRowSelectionWithLargeHeightFixture = document.getElementById('serverSmartRowSelectionWithLargeHeight');
+  serverSmartRowSelectionWithLargeHeightFixture = document.getElementById('greedyHeightWithScrollDataRemote');
   serverSmartRowSelectionWithLargeHeightFixture.tableData = minidata;
 
   runTests();

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -1,4 +1,7 @@
-var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, filtertest, resetDataFixture, additionalDataFixture, updateSelectFixture, remoteDataFixture1, remoteDataFixture2, remoteDataFixture3,remoteDataFilteringFixture1, remoteDataFilteringFixture2, greedyHeightWithScrollFixture, clientSmartRowSelectionWithLargeHeightFixture, serverSmartRowSelectionWithLargeHeightFixture;
+var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, filtertest, 
+resetDataFixture, additionalDataFixture, updateSelectFixture, remoteDataFixture1, remoteDataFixture2, 
+remoteDataFixture3,remoteDataFilteringFixture1, remoteDataFilteringFixture2, greedyHeightWithScrollFixture,
+clientSmartRowSelectionWithLargeHeightFixture, serverSmartRowSelectionWithLargeHeightFixture;
 var getStyle = function (el, style){
   return window.getComputedStyle( el, null ).getPropertyValue( style );
 };
@@ -1604,29 +1607,28 @@ function runTests() {
     });
 
     suite('smart row selection for client or server side pagination', function () {
-      test('_optimizePageForLoad for client with small view size', function(done) {
+      test('_initializeTable for client with small view size', function(done) {
         var pxTable = document.getElementById('greedyHeightWithScroll');
-        var container = Polymer.dom(this.root).querySelector('#flexContainer1');
         var pageSizeSelect = pxTable.querySelector('#pageSizeSelect');
         assert.equal(pageSizeSelect.value, 10, 'small view size select page size 10');
         done();
       });
 
-      test('_optimizePageForLoad for client with large view size', function(done) {
-        var pxTable = document.getElementById('clientSmartRowSelectionWithLargeHeight');
-        var container = Polymer.dom(this.root).querySelector('#flexContainer2');
+      test('_initializeTable for client with large view size', function(done) {
+        var pxTable = document.getElementById('greedyHeightWithScrollLarge');
         var pageSizeSelect = pxTable.querySelector('#pageSizeSelect');
         assert.equal(pageSizeSelect.value, 20, 'large view size select closest page size');
         done();
       });
 
-       test('_optimizePageForLoad for remote data is true', function(done) {
-        var pxTable = document.getElementById('serverSmartRowSelectionWithLargeHeight');
-        var container = Polymer.dom(this.root).querySelector('#flexContainer3');
+       test('_initializeTable for remote data is true', function(done) {
+        var pxTable = document.getElementById('greedyHeightWithScrollDataRemote');
         var pageSizeSelect = pxTable.querySelector('#pageSizeSelect');
         assert.equal(pageSizeSelect.value, 10, 'server side pagination send out the closest page size as requested page size');
         done();
       });
+
+    });
 
     suite('Filtering', function () {
 

--- a/test/px-data-table-test.js
+++ b/test/px-data-table-test.js
@@ -1,7 +1,7 @@
 var table1Fixture, table2Fixture, table3Fixture, table4Fixture, table5Fixture, filtertest, 
 resetDataFixture, additionalDataFixture, updateSelectFixture, remoteDataFixture1, remoteDataFixture2, 
 remoteDataFixture3,remoteDataFilteringFixture1, remoteDataFilteringFixture2, greedyHeightWithScrollFixture,
-clientSmartRowSelectionWithLargeHeightFixture, serverSmartRowSelectionWithLargeHeightFixture;
+greedyHeightWithScrollLargeFixture, greedyHeightWithScrollDataRemoteFixture;
 var getStyle = function (el, style){
   return window.getComputedStyle( el, null ).getPropertyValue( style );
 };
@@ -799,11 +799,11 @@ document.addEventListener("WebComponentsReady", function() {
   greedyHeightWithScrollFixture = document.getElementById('greedyHeightWithScroll');
   greedyHeightWithScrollFixture.tableData = minidata;
 
-  clientSmartRowSelectionWithLargeHeightFixture = document.getElementById('greedyHeightWithScrollLarge');
-  clientSmartRowSelectionWithLargeHeightFixture.tableData = minidata;
+  greedyHeightWithScrollLargeFixture = document.getElementById('greedyHeightWithScrollLarge');
+  greedyHeightWithScrollLargeFixture.tableData = minidata;
 
-  serverSmartRowSelectionWithLargeHeightFixture = document.getElementById('greedyHeightWithScrollDataRemote');
-  serverSmartRowSelectionWithLargeHeightFixture.tableData = minidata;
+  greedyHeightWithScrollDataRemoteFixture = document.getElementById('greedyHeightWithScrollDataRemote');
+  greedyHeightWithScrollDataRemoteFixture.tableData = minidata;
 
   runTests();
 });


### PR DESCRIPTION
# Technical Debt
- Row height can't not be detected from css; hard coded as a static number

# Smart row detection for handling both server side and client side pagination
- Handle client and server side data source (`remoteData`) differently for smart row detection
- On client side pagination, smart row detection will toggle page size at window load
- On server side pagination, smart row detection will fire event on am-alarm-grid
