### PR TITLE
Filter input element for a column should not be hidden

### DIFF
--- a/aha-table.html
+++ b/aha-table.html
@@ -1629,7 +1629,7 @@
     },
 
     _isFilterableColumn: function(column) {
-      return !column.selectAll && column.filterable && this.filterable && !column.hide;
+      return !column.selectAll && column.filterable && this.filterable;
     },
 
     _readContent: function (row, column) {


### PR DESCRIPTION
## Description
There are some edge cases where the input cells in the filter row are not showing up, removing the condition that hides the filter input box

## Tests 
49 passing wct tests